### PR TITLE
Improve unit tests and remove EntityGenerator->combine

### DIFF
--- a/src/SectionField/Generator/EntityGenerator.php
+++ b/src/SectionField/Generator/EntityGenerator.php
@@ -136,21 +136,12 @@ public function getDefault(): string
 EOT;
     }
 
-    private function combine(array $templates): string
-    {
-        $combined = '';
-        foreach ($templates as $template) {
-            $combined .= $template;
-        }
-        return $combined;
-    }
-
     private function insertRenderedTemplates(string $template): string
     {
         foreach ($this->templates as $templateVariable=>$templates) {
             $template = str_replace(
                 '{{ ' . $templateVariable . ' }}',
-                $this->combine($templates),
+                \implode($templates),
                 $template
             );
         }

--- a/test/unit/FieldType/Relationship/Generator/EntityPropertiesGeneratorTest.php
+++ b/test/unit/FieldType/Relationship/Generator/EntityPropertiesGeneratorTest.php
@@ -47,7 +47,7 @@ final class EntityPropertiesGeneratorTest extends TestCase
             ->andReturn('PauloClass');
 
         $options = ['sectionConfig' => $mockedSectionConfig];
-        $generatedTemplate = EntityMethodsGenerator::generate($mockedFieldInterface, $templateDir, $options);
+        $generatedTemplate = EntityPropertiesGenerator::generate($mockedFieldInterface, $templateDir, $options);
         $this->assertInstanceOf(Template::class, $generatedTemplate);
         $this->assertFalse((string)$generatedTemplate === '');
     }

--- a/test/unit/FieldType/Slug/Generator/EntityPrePersistGeneratorTest.php
+++ b/test/unit/FieldType/Slug/Generator/EntityPrePersistGeneratorTest.php
@@ -18,6 +18,7 @@ class EntityPrePersistGeneratorTest extends TestCase
     /**
      * @test
      * @covers ::generate
+     * @covers ::<private>
      */
     public function it_should_generate()
     {
@@ -36,7 +37,7 @@ class EntityPrePersistGeneratorTest extends TestCase
                             'to' => 'you',
                             'generator' => [
                                 'entity' => [
-                                    'slugFields' => ['snail', 'sexy']
+                                    'slugFields' => ['snail', 'sexy|DateTime|Y-m-d']
                                 ]
                             ]
                         ]
@@ -48,7 +49,7 @@ class EntityPrePersistGeneratorTest extends TestCase
         $this->assertInstanceOf(Template::class, $generatedTemplate);
         $this->assertFalse((string)$generatedTemplate === '');
         $this->assertEquals(
-            '$this->niets = Tardigrades\Helper\StringConverter::toSlug($this->getSnail() . \'-\' . $this->getSexy());
+            '$this->niets = Tardigrades\Helper\StringConverter::toSlug($this->getSnail() . \'-\' . $this->getSexy()->format(\'Y-m-d\'));
 ',
             (string) $generatedTemplate);
     }


### PR DESCRIPTION
`EntityGenerator->combine` just reimplemented `implode`.
`EntityPropertiesGeneratorTest` tested `EntityMethodsGenerator` instead of `EntityPropertiesGenerator`.
`EntityPrePersistGeneratorTest` now tests formatted slugs.