### PR TITLE
allow use of field aliases in relationships

### DIFF
--- a/src/FieldType/Relationship/Generator/EntityMethodsGenerator.php
+++ b/src/FieldType/Relationship/Generator/EntityMethodsGenerator.php
@@ -30,16 +30,18 @@ class EntityMethodsGenerator implements GeneratorInterface
         /** @var SectionConfig $sectionConfig */
         $sectionConfig = $options[0]['sectionConfig'];
 
+        $toHandle = $fieldConfig['field']['as'] ?? $fieldConfig['field']['to'];
+
         return Template::create((string) TemplateLoader::load(
             (string) $templateDir .
             '/GeneratorTemplate/entity.methods.php',
             [
                 'kind' => $fieldConfig['field']['kind'],
-                'pluralMethodName' => ucfirst(Inflector::pluralize($fieldConfig['field']['to'])),
-                'pluralPropertyName' => Inflector::pluralize($fieldConfig['field']['to']),
-                'methodName' => ucfirst($fieldConfig['field']['to']),
+                'pluralMethodName' => ucfirst(Inflector::pluralize($toHandle)),
+                'pluralPropertyName' => Inflector::pluralize($toHandle),
+                'methodName' => ucfirst($toHandle),
                 'entity' => ucfirst($fieldConfig['field']['to']),
-                'propertyName' => $fieldConfig['field']['to'],
+                'propertyName' => $toHandle,
                 'thatMethodName' => $sectionConfig->getClassName()
             ]
         ));

--- a/src/FieldType/Relationship/Generator/EntityPropertiesGenerator.php
+++ b/src/FieldType/Relationship/Generator/EntityPropertiesGenerator.php
@@ -26,14 +26,16 @@ class EntityPropertiesGenerator implements GeneratorInterface
     {
         $fieldConfig = $field->getConfig()->toArray();
 
+        $toHandle = $fieldConfig['field']['as'] ?? $fieldConfig['field']['to'];
+
         return Template::create((string) TemplateLoader::load(
             $templateDir .
             '/GeneratorTemplate/entity.properties.php',
             [
                 'kind' => $fieldConfig['field']['kind'],
-                'pluralPropertyName' => Inflector::pluralize($fieldConfig['field']['to']),
+                'pluralPropertyName' => Inflector::pluralize($toHandle),
                 'entity' => ucfirst($fieldConfig['field']['to']),
-                'propertyName' => $fieldConfig['field']['to']
+                'propertyName' => $toHandle
             ]
         ));
     }

--- a/test/unit/FieldType/Relationship/Generator/EntityMethodsGeneratorTest.php
+++ b/test/unit/FieldType/Relationship/Generator/EntityMethodsGeneratorTest.php
@@ -37,18 +37,115 @@ final class EntityMethodsGeneratorTest extends TestCase
                             'handle' => 'niets',
                             'kind' => 'one-to-many',
                             'entityEvents' => ['1', '2'],
-                            'to' => 'me!'
+                            'to' => 'me'
                         ]
                     ]
                 )
             );
 
         $mockedSectionConfig->shouldReceive('getClassName')
-            ->andReturn('this one');
+            ->andReturn('MyClass');
 
         $options = ['sectionConfig' => $mockedSectionConfig];
+        $expected = <<<'EOT'
+public function getMes(): Collection
+{
+    return $this->mes;
+}
+
+public function addMe(Me $me): {{ section }}
+{
+    if ($this->mes->contains($me)) {
+        return $this;
+    }
+    $this->mes->add($me);
+        $me->setMyClass($this);
+        
+    return $this;
+}
+
+public function removeMe(Me $me): {{ section }}
+{
+    if (!$this->mes->contains($me)) {
+        return $this;
+    }
+    $this->mes->removeElement($me);
+        $me->removeMyClass($this);
+    
+    return $this;
+}
+
+
+EOT;
+
         $generatedTemplate = EntityMethodsGenerator::generate($mockedFieldInterface, $templateDir, $options);
         $this->assertInstanceOf(Template::class, $generatedTemplate);
-        $this->assertFalse((string)$generatedTemplate === '');
+        $this->assertSame($expected, (string)$generatedTemplate);
+    }
+
+    /**
+     * @test
+     * @covers ::generate
+     */
+    public function it_generates_using_field_aliases_in_relationship()
+    {
+        $mockedFieldInterface = Mockery::mock(new Field())->makePartial();
+        $mockedSectionConfig = Mockery::mock('alias:SectionConfig')->makePartial();
+        $templateDir = TemplateDir::fromString('src/FieldType/Relationship');
+
+        $mockedFieldInterface->shouldReceive('getConfig')
+            ->andReturn(
+                FieldConfig::fromArray(
+                    [
+                        'field' => [
+                            'name' => 'iets',
+                            'handle' => 'niets',
+                            'kind' => 'one-to-many',
+                            'entityEvents' => ['1', '2'],
+                            'to' => 'me',
+                            'as' => 'somethingElse'
+                        ]
+                    ]
+                )
+            );
+
+        $mockedSectionConfig->shouldReceive('getClassName')
+            ->andReturn('MyClass');
+
+        $options = ['sectionConfig' => $mockedSectionConfig];
+        $expected = <<<'EOT'
+public function getSomethingElses(): Collection
+{
+    return $this->somethingElses;
+}
+
+public function addSomethingElse(Me $somethingElse): {{ section }}
+{
+    if ($this->somethingElses->contains($somethingElse)) {
+        return $this;
+    }
+    $this->somethingElses->add($somethingElse);
+        $somethingElse->setMyClass($this);
+        
+    return $this;
+}
+
+public function removeSomethingElse(Me $somethingElse): {{ section }}
+{
+    if (!$this->somethingElses->contains($somethingElse)) {
+        return $this;
+    }
+    $this->somethingElses->removeElement($somethingElse);
+        $somethingElse->removeMyClass($this);
+    
+    return $this;
+}
+
+
+EOT;
+
+        $generatedTemplate = EntityMethodsGenerator::generate($mockedFieldInterface, $templateDir, $options);
+        $this->assertInstanceOf(Template::class, $generatedTemplate);
+        $this->assertSame($expected, (string)$generatedTemplate);
     }
 }

--- a/test/unit/FieldType/Relationship/Generator/EntityPropertiesGeneratorTest.php
+++ b/test/unit/FieldType/Relationship/Generator/EntityPropertiesGeneratorTest.php
@@ -46,9 +46,58 @@ final class EntityPropertiesGeneratorTest extends TestCase
         $mockedSectionConfig->shouldReceive('getClassName')
             ->andReturn('PauloClass');
 
+        $expected = <<<'EOT'
+/** @var ArrayCollection */
+protected $yous;
+
+
+EOT;
+
         $options = ['sectionConfig' => $mockedSectionConfig];
         $generatedTemplate = EntityPropertiesGenerator::generate($mockedFieldInterface, $templateDir, $options);
         $this->assertInstanceOf(Template::class, $generatedTemplate);
-        $this->assertFalse((string)$generatedTemplate === '');
+        $this->assertSame($expected, (string)$generatedTemplate);
+    }
+
+    /**
+     * @test
+     * @covers ::generate
+     */
+    public function it_generates_and_uses_field_aliases()
+    {
+        $mockedFieldInterface = Mockery::mock(new Field())->makePartial();
+        $mockedSectionConfig = Mockery::mock('alias:SectionConfig')->makePartial();
+        $templateDir = TemplateDir::fromString('src/FieldType/Relationship');
+
+        $mockedFieldInterface->shouldReceive('getConfig')
+            ->andReturn(
+                FieldConfig::fromArray(
+                    [
+                        'field' => [
+                            'name' => 'iets',
+                            'handle' => 'niets',
+                            'kind' => 'one-to-many',
+                            'entityEvents' => ['1', '2'],
+                            'to' => 'you',
+                            'as' => 'somethingElse'
+                        ]
+                    ]
+                )
+            );
+
+        $mockedSectionConfig->shouldReceive('getClassName')
+            ->andReturn('PauloClass');
+
+        $expected = <<<'EOT'
+/** @var ArrayCollection */
+protected $somethingElses;
+
+
+EOT;
+
+        $options = ['sectionConfig' => $mockedSectionConfig];
+        $generatedTemplate = EntityPropertiesGenerator::generate($mockedFieldInterface, $templateDir, $options);
+        $this->assertInstanceOf(Template::class, $generatedTemplate);
+        $this->assertSame($expected, (string)$generatedTemplate);
     }
 }

--- a/test/unit/FieldType/Slug/Generator/EntityPrePersistGeneratorTest.php
+++ b/test/unit/FieldType/Slug/Generator/EntityPrePersistGeneratorTest.php
@@ -49,10 +49,11 @@ class EntityPrePersistGeneratorTest extends TestCase
         $this->assertInstanceOf(Template::class, $generatedTemplate);
         $this->assertFalse((string)$generatedTemplate === '');
 
+        // @codingStandardsIgnoreStart
         $this->assertContains(
-            // phpcs:ignore Generic.Files.LineLength
             '$this->niets = Tardigrades\Helper\StringConverter::toSlug($this->getSnail() . \'-\' . $this->getSexy()->format(\'Y-m-d\'));',
             (string) $generatedTemplate
         );
+        // @codingStandardsIgnoreEnd
     }
 }


### PR DESCRIPTION
When the relationship field config has a key 'as' then that field will be generated in the entity. This is useful when you want to create two relationships to the same entity. Without this option, only one field would be created.