### PR TITLE
Make generated code more correct

### DIFF
--- a/src/FieldType/Choice/GeneratorTemplate/entity.properties.php.template
+++ b/src/FieldType/Choice/GeneratorTemplate/entity.properties.php.template
@@ -1,2 +1,2 @@
-/** @var {{ nullable }}string */
+/** @var ?string */
 protected ${{ propertyName }};

--- a/src/FieldType/DateTime/GeneratorTemplate/entity.properties.php.template
+++ b/src/FieldType/DateTime/GeneratorTemplate/entity.properties.php.template
@@ -1,2 +1,2 @@
-/** @var {{ nullable }}\DateTime */
+/** @var ?\DateTime */
 protected ${{ propertyName }};

--- a/src/FieldType/Email/GeneratorTemplate/entity.properties.php.template
+++ b/src/FieldType/Email/GeneratorTemplate/entity.properties.php.template
@@ -1,2 +1,2 @@
-/** @var {{ nullable }}string */
+/** @var ?string */
 protected ${{ propertyName }};

--- a/src/FieldType/Generator/EntityPropertiesGenerator.php
+++ b/src/FieldType/Generator/EntityPropertiesGenerator.php
@@ -22,27 +22,9 @@ class EntityPropertiesGenerator implements GeneratorInterface
 {
     public static function generate(FieldInterface $field, TemplateDir $templateDir): Template
     {
-        $nullable = true;
-
-        try {
-            $generatorConfig = $field->getConfig()->getGeneratorConfig()->toArray();
-
-            if (!$generatorConfig['entity']['validator']['NotBlank']) { //which means the yml tilde: use default value
-                $nullable = false;
-            }
-        } catch (\Exception $e) {
-            //
-        }
-        
         $asString = (string) TemplateLoader::load(
             (string) $templateDir .
             '/GeneratorTemplate/entity.properties.php.template'
-        );
-
-        $asString = str_replace(
-            '{{ nullable }}',
-            $nullable ? '?' : '',
-            $asString
         );
 
         $asString = str_replace(

--- a/src/FieldType/Integer/GeneratorTemplate/entity.properties.php.template
+++ b/src/FieldType/Integer/GeneratorTemplate/entity.properties.php.template
@@ -1,2 +1,2 @@
-/** @var {{ nullable }}int */
+/** @var ?int */
 protected ${{ propertyName }};

--- a/src/FieldType/Number/GeneratorTemplate/entity.properties.php.template
+++ b/src/FieldType/Number/GeneratorTemplate/entity.properties.php.template
@@ -1,2 +1,2 @@
-/** @var {{ nullable }}float */
+/** @var ?float */
 protected ${{ propertyName }};

--- a/src/FieldType/Relationship/Generator/EntityMethodsGenerator.php
+++ b/src/FieldType/Relationship/Generator/EntityMethodsGenerator.php
@@ -31,7 +31,11 @@ class EntityMethodsGenerator implements GeneratorInterface
         $sectionConfig = $options[0]['sectionConfig'];
 
         $toHandle = $fieldConfig['field']['as'] ?? $fieldConfig['field']['to'];
-        $thatMethodName = $fieldConfig['field']['from-handle'] ?? $sectionConfig->getClassName();
+        if (isset($fieldConfig['field']['from-handle'])) {
+            $thatMethodName = ucfirst($fieldConfig['field']['from-handle']);
+        } else {
+            $thatMethodName = $sectionConfig->getClassName();
+        }
 
         return Template::create((string) TemplateLoader::load(
             (string) $templateDir .

--- a/src/FieldType/Relationship/Generator/EntityMethodsGenerator.php
+++ b/src/FieldType/Relationship/Generator/EntityMethodsGenerator.php
@@ -37,6 +37,7 @@ class EntityMethodsGenerator implements GeneratorInterface
             '/GeneratorTemplate/entity.methods.php',
             [
                 'kind' => $fieldConfig['field']['kind'],
+                'type' => $fieldConfig['field']['relationship-type'],
                 'pluralMethodName' => ucfirst(Inflector::pluralize($toHandle)),
                 'pluralPropertyName' => Inflector::pluralize($toHandle),
                 'methodName' => ucfirst($toHandle),

--- a/src/FieldType/Relationship/Generator/EntityMethodsGenerator.php
+++ b/src/FieldType/Relationship/Generator/EntityMethodsGenerator.php
@@ -31,6 +31,7 @@ class EntityMethodsGenerator implements GeneratorInterface
         $sectionConfig = $options[0]['sectionConfig'];
 
         $toHandle = $fieldConfig['field']['as'] ?? $fieldConfig['field']['to'];
+        $thatMethodName = $fieldConfig['field']['from-handle'] ?? $sectionConfig->getClassName();
 
         return Template::create((string) TemplateLoader::load(
             (string) $templateDir .
@@ -43,7 +44,7 @@ class EntityMethodsGenerator implements GeneratorInterface
                 'methodName' => ucfirst($toHandle),
                 'entity' => ucfirst($fieldConfig['field']['to']),
                 'propertyName' => $toHandle,
-                'thatMethodName' => $sectionConfig->getClassName()
+                'thatMethodName' => $thatMethodName
             ]
         ));
     }

--- a/src/FieldType/Relationship/GeneratorTemplate/entity.methods.php
+++ b/src/FieldType/Relationship/GeneratorTemplate/entity.methods.php
@@ -10,12 +10,11 @@ public function add<?php echo $methodName; ?>(<?php echo $entity; ?> $<?php echo
         return $this;
     }
     $this-><?php echo $pluralPropertyName; ?>->add($<?php echo $propertyName; ?>);
-    <?php if ($kind === 'one-to-many') { ?>
+<?php if ($kind === 'one-to-many') { ?>
     $<?php echo $propertyName; ?>->set<?php echo $thatMethodName; ?>($this);
-    <?php } ?>
-    <?php if ($kind === 'many-to-many') { ?>
+<?php } elseif ($kind === 'many-to-many') { ?>
     $<?php echo $propertyName; ?>->add<?php echo $thatMethodName; ?>($this);
-    <?php } ?>
+<?php } ?>
 
     return $this;
 }
@@ -26,15 +25,17 @@ public function remove<?php echo $methodName; ?>(<?php echo $entity; ?> $<?php e
         return $this;
     }
     $this-><?php echo $pluralPropertyName; ?>->removeElement($<?php echo $propertyName; ?>);
-    <?php if ($kind === 'one-to-many') { ?>
+<?php if ($kind === 'one-to-many') { ?>
+    $<?php echo $propertyName; ?>->remove<?php echo $thatMethodName; ?>();
+<?php } elseif ($kind === 'many-to-many') {?>
     $<?php echo $propertyName; ?>->remove<?php echo $thatMethodName; ?>($this);
-    <?php } ?>
+<?php } ?>
 
     return $this;
 }
-<?php } ?>
+<?php }
 
-<?php if ($kind === 'many-to-one' || $kind === 'one-to-one') { ?>
+if ($kind === 'many-to-one' || $kind === 'one-to-one') { ?>
 public function get<?php echo $methodName; ?>(): ?<?php echo $entity . PHP_EOL; ?>
 {
     return $this-><?php echo $propertyName; ?>;
@@ -47,15 +48,31 @@ public function has<?php echo $methodName; ?>(): bool
 
 public function set<?php echo $methodName; ?>(<?php echo $entity; ?> $<?php echo $propertyName; ?>): {{ section }}
 {
+    if ($this-><?php echo $propertyName; ?> === $<?php echo $propertyName; ?>) {
+        return $this;
+    }
     $this-><?php echo $propertyName; ?> = $<?php echo $propertyName; ?>;
+<?php if ($kind === 'many-to-one') { ?>
+    $<?php echo $propertyName; ?>->add<?php echo $thatMethodName; ?>($this);
+<?php } elseif ($kind === 'one-to-one') { ?>
+    $<?php echo $propertyName; ?>->set<?php echo $thatMethodName; ?>($this);
+<?php } ?>
 
     return $this;
 }
 
 public function remove<?php echo $methodName; ?>(): {{ section }}
 {
+    if ($this-><?php echo $propertyName; ?> === null) {
+        return $this;
+    }
     $this-><?php echo $propertyName; ?> = null;
+<?php if ($kind === 'many-to-one') { ?>
+    $<?php echo $propertyName; ?>->remove<?php echo $thatMethodName; ?>($this);
+<?php } elseif ($kind === 'one-to-one') {?>
+    $<?php echo $propertyName; ?>->remove<?php echo $thatMethodName; ?>();
+<?php } ?>
 
     return $this;
 }
-<?php } ?>
+<?php }

--- a/src/FieldType/Relationship/GeneratorTemplate/entity.methods.php
+++ b/src/FieldType/Relationship/GeneratorTemplate/entity.methods.php
@@ -67,7 +67,7 @@ public function remove<?php echo $methodName; ?>(): {{ section }}
         return $this;
     }
 <?php if ($type === 'bidirectional') { ?>
-    /** @var <?php echo $entity; ?> */
+    /** @var <?php echo $entity; ?> $<?php echo $propertyName; ?> */
     $<?php echo $propertyName; ?> = $this-><?php echo $propertyName; ?>;
 <?php } ?>
     $this-><?php echo $propertyName; ?> = null;

--- a/src/FieldType/Relationship/GeneratorTemplate/entity.methods.php
+++ b/src/FieldType/Relationship/GeneratorTemplate/entity.methods.php
@@ -66,6 +66,7 @@ public function remove<?php echo $methodName; ?>(): {{ section }}
     if ($this-><?php echo $propertyName; ?> === null) {
         return $this;
     }
+    $<?php echo $propertyName; ?> = $this-><?php echo $propertyName; ?>;
     $this-><?php echo $propertyName; ?> = null;
 <?php if ($kind === 'many-to-one') { ?>
     $<?php echo $propertyName; ?>->remove<?php echo $thatMethodName; ?>($this);

--- a/src/FieldType/Relationship/GeneratorTemplate/entity.methods.php
+++ b/src/FieldType/Relationship/GeneratorTemplate/entity.methods.php
@@ -10,9 +10,9 @@ public function add<?php echo $methodName; ?>(<?php echo $entity; ?> $<?php echo
         return $this;
     }
     $this-><?php echo $pluralPropertyName; ?>->add($<?php echo $propertyName; ?>);
-<?php if ($kind === 'one-to-many') { ?>
+<?php if ($kind === 'one-to-many' && $type === 'bidirectional') { ?>
     $<?php echo $propertyName; ?>->set<?php echo $thatMethodName; ?>($this);
-<?php } elseif ($kind === 'many-to-many') { ?>
+<?php } elseif ($kind === 'many-to-many' && $type === 'bidirectional') { ?>
     $<?php echo $propertyName; ?>->add<?php echo $thatMethodName; ?>($this);
 <?php } ?>
 
@@ -25,9 +25,9 @@ public function remove<?php echo $methodName; ?>(<?php echo $entity; ?> $<?php e
         return $this;
     }
     $this-><?php echo $pluralPropertyName; ?>->removeElement($<?php echo $propertyName; ?>);
-<?php if ($kind === 'one-to-many') { ?>
+<?php if ($kind === 'one-to-many' && $type === 'bidirectional') { ?>
     $<?php echo $propertyName; ?>->remove<?php echo $thatMethodName; ?>();
-<?php } elseif ($kind === 'many-to-many') {?>
+<?php } elseif ($kind === 'many-to-many' && $type === 'bidirectional') {?>
     $<?php echo $propertyName; ?>->remove<?php echo $thatMethodName; ?>($this);
 <?php } ?>
 
@@ -52,9 +52,9 @@ public function set<?php echo $methodName; ?>(<?php echo $entity; ?> $<?php echo
         return $this;
     }
     $this-><?php echo $propertyName; ?> = $<?php echo $propertyName; ?>;
-<?php if ($kind === 'many-to-one') { ?>
+<?php if ($kind === 'many-to-one' && $type === 'bidirectional') { ?>
     $<?php echo $propertyName; ?>->add<?php echo $thatMethodName; ?>($this);
-<?php } elseif ($kind === 'one-to-one') { ?>
+<?php } elseif ($kind === 'one-to-one' && $type === 'bidirectional') { ?>
     $<?php echo $propertyName; ?>->set<?php echo $thatMethodName; ?>($this);
 <?php } ?>
 
@@ -66,11 +66,13 @@ public function remove<?php echo $methodName; ?>(): {{ section }}
     if ($this-><?php echo $propertyName; ?> === null) {
         return $this;
     }
+<?php if ($type === 'bidirectional') { ?>
     $<?php echo $propertyName; ?> = $this-><?php echo $propertyName; ?>;
+<?php } ?>
     $this-><?php echo $propertyName; ?> = null;
-<?php if ($kind === 'many-to-one') { ?>
+<?php if ($kind === 'many-to-one' && $type === 'bidirectional') { ?>
     $<?php echo $propertyName; ?>->remove<?php echo $thatMethodName; ?>($this);
-<?php } elseif ($kind === 'one-to-one') {?>
+<?php } elseif ($kind === 'one-to-one' && $type === 'bidirectional') {?>
     $<?php echo $propertyName; ?>->remove<?php echo $thatMethodName; ?>();
 <?php } ?>
 

--- a/src/FieldType/Relationship/GeneratorTemplate/entity.methods.php
+++ b/src/FieldType/Relationship/GeneratorTemplate/entity.methods.php
@@ -1,5 +1,5 @@
 <?php if ($kind === 'one-to-many' || $kind === 'many-to-many') { ?>
-public function get<?php echo $pluralMethodName; ?>(): ?Collection
+public function get<?php echo $pluralMethodName; ?>(): Collection
 {
     return $this-><?php echo $pluralPropertyName; ?>;
 }

--- a/src/FieldType/Relationship/GeneratorTemplate/entity.methods.php
+++ b/src/FieldType/Relationship/GeneratorTemplate/entity.methods.php
@@ -67,6 +67,7 @@ public function remove<?php echo $methodName; ?>(): {{ section }}
         return $this;
     }
 <?php if ($type === 'bidirectional') { ?>
+    /** @var <?php echo $entity; ?> */
     $<?php echo $propertyName; ?> = $this-><?php echo $propertyName; ?>;
 <?php } ?>
     $this-><?php echo $propertyName; ?> = null;

--- a/src/FieldType/Relationship/GeneratorTemplate/entity.properties.php
+++ b/src/FieldType/Relationship/GeneratorTemplate/entity.properties.php
@@ -4,6 +4,6 @@ protected $<?php echo $pluralPropertyName; ?>;
 <?php } ?>
 
 <?php if ($kind === 'many-to-one' || $kind === 'one-to-one') { ?>
-/** @var <?php echo $entity; ?> */
+/** @var ?<?php echo $entity; ?> */
 protected $<?php echo $propertyName; ?>;
 <?php } ?>

--- a/src/FieldType/RichTextArea/GeneratorTemplate/entity.properties.php.template
+++ b/src/FieldType/RichTextArea/GeneratorTemplate/entity.properties.php.template
@@ -1,2 +1,2 @@
-/** @var {{ nullable }}string */
+/** @var ?string */
 protected ${{ propertyName }};

--- a/src/FieldType/Slug/Generator/EntityPrePersistGenerator.php
+++ b/src/FieldType/Slug/Generator/EntityPrePersistGenerator.php
@@ -63,7 +63,7 @@ class EntityPrePersistGenerator implements GeneratorInterface
         $assignment = [];
         foreach ($slug->toArray() as $element) {
             $element = explode('|', $element);
-            $value = '$this->get' . Inflector::classify($element[0]) . '()';
+            $value = "\$$element[0]";
             if (count($element) > 1) {
                 switch ($element[1]) {
                     case 'DateTime':
@@ -81,9 +81,10 @@ class EntityPrePersistGenerator implements GeneratorInterface
         $body = '';
         foreach ($slug->toArray() as $element) {
             $element = explode('|', $element);
-            $value = '$this->get' . Inflector::classify($element[0]) . '()';
+            $getter = '$this->get' . Inflector::classify($element[0]) . '()';
             $body .= <<<EOT
-if ($value === null) {
+\$$element[0] = $getter;
+if (\$$element[0] === null) {
     throw new \UnexpectedValueException('$element[0] is null, cannot build slug');
 }
 

--- a/src/FieldType/Slug/Generator/EntityPrePersistGenerator.php
+++ b/src/FieldType/Slug/Generator/EntityPrePersistGenerator.php
@@ -39,13 +39,19 @@ class EntityPrePersistGenerator implements GeneratorInterface
             $asString
         );
 
+        $slug = SlugValueObject::create(
+            $field->getConfig()->getGeneratorConfig()->toArray()['entity']['slugFields']
+        );
+
+        $asString = str_replace(
+            '{{ verification }}',
+            self::makeSlugVerification($slug),
+            $asString
+        );
+
         $asString = str_replace(
             '{{ assignment }}',
-            self::makeSlugAssignment(
-                SlugValueObject::create(
-                    $field->getConfig()->getGeneratorConfig()->toArray()['entity']['slugFields']
-                )
-            ),
+            self::makeSlugAssignment($slug),
             $asString
         );
 
@@ -57,16 +63,32 @@ class EntityPrePersistGenerator implements GeneratorInterface
         $assignment = [];
         foreach ($slug->toArray() as $element) {
             $element = explode('|', $element);
-            $attach = '';
+            $value = '$this->get' . Inflector::classify($element[0]) . '()';
             if (count($element) > 1) {
                 switch ($element[1]) {
                     case 'DateTime':
-                        $attach = '->format(\'' . $element[2] . '\')';
+                        $value .= "->format('$element[2]')";
                         break;
                 }
             }
-            $assignment[] = '$this->get' . Inflector::classify($element[0]) . '()' . $attach;
+            $assignment[] = $value;
         }
-        return 'Tardigrades\Helper\StringConverter::toSlug(' . implode(' . \'-\' . ', $assignment) . ');';
+        return 'Tardigrades\Helper\StringConverter::toSlug(' . implode(" . '-' . ", $assignment) . ');';
+    }
+
+    private static function makeSlugVerification(SlugValueObject $slug): string
+    {
+        $body = '';
+        foreach ($slug->toArray() as $element) {
+            $element = explode('|', $element);
+            $value = '$this->get' . Inflector::classify($element[0]) . '()';
+            $body .= <<<EOT
+if ($value === null) {
+    throw new \UnexpectedValueException('$element[0] is null, cannot build slug');
+}
+
+EOT;
+        }
+        return $body;
     }
 }

--- a/src/FieldType/Slug/GeneratorTemplate/entity.prepersist.php.template
+++ b/src/FieldType/Slug/GeneratorTemplate/entity.prepersist.php.template
@@ -1,3 +1,3 @@
-// phpcs:ignore Generic.Files.LineLength
 {{ verification }}
+// phpcs:ignore Generic.Files.LineLength
 $this->{{ propertyName }} = {{ assignment }}

--- a/src/FieldType/Slug/GeneratorTemplate/entity.prepersist.php.template
+++ b/src/FieldType/Slug/GeneratorTemplate/entity.prepersist.php.template
@@ -1,2 +1,3 @@
 // phpcs:ignore Generic.Files.LineLength
+{{ verification }}
 $this->{{ propertyName }} = {{ assignment }}

--- a/src/FieldType/Slug/GeneratorTemplate/entity.properties.php.template
+++ b/src/FieldType/Slug/GeneratorTemplate/entity.properties.php.template
@@ -1,2 +1,2 @@
-/** @var {{ nullable }}string */
+/** @var ?string */
 protected ${{ propertyName }};

--- a/src/FieldType/TextArea/GeneratorTemplate/entity.properties.php.template
+++ b/src/FieldType/TextArea/GeneratorTemplate/entity.properties.php.template
@@ -1,2 +1,2 @@
-/** @var {{ nullable }}string */
+/** @var ?string */
 protected ${{ propertyName }};

--- a/src/FieldType/TextInput/GeneratorTemplate/entity.properties.php.template
+++ b/src/FieldType/TextInput/GeneratorTemplate/entity.properties.php.template
@@ -1,2 +1,2 @@
-/** @var {{ nullable }}string */
+/** @var ?string */
 protected ${{ propertyName }};

--- a/src/FieldType/Uuid/GeneratorTemplate/entity.properties.php.template
+++ b/src/FieldType/Uuid/GeneratorTemplate/entity.properties.php.template
@@ -1,2 +1,2 @@
-/** @var {{ nullable }}string */
+/** @var ?string */
 protected ${{ propertyName }};

--- a/src/SectionField/Generator/EntityGenerator.php
+++ b/src/SectionField/Generator/EntityGenerator.php
@@ -227,7 +227,7 @@ class EntityGenerator extends Generator implements GeneratorInterface
 public function getSlug(): Tardigrades\SectionField\ValueObject\Slug
 {
     if (\$this->{$slugField} === null) {
-        throw new \UnexpectedValueException('\$this->{$slugField} is null, cannot build slug');
+        throw new \UnexpectedValueException('\$this->{$slugField} is null, no slug built');
     }
     return Tardigrades\SectionField\ValueObject\Slug::fromString(\$this->{$slugField});
 }
@@ -243,7 +243,7 @@ EOT;
 public function getDefault(): string
 {
     if (\$this->{$defaultField} === null) {
-        throw new \UnexpectedValueException('\$this->{$defaultField} is null, cannot get default value');
+        throw new \UnexpectedValueException('{$defaultField} is null, cannot get default value');
     }
     return \$this->{$defaultField};
 }

--- a/src/SectionField/Generator/EntityGenerator.php
+++ b/src/SectionField/Generator/EntityGenerator.php
@@ -239,6 +239,9 @@ EOT;
         return <<<EOT
 public function getDefault(): string
 {
+    if (\$this->{$defaultField} === null) {
+        throw new \UnexpectedValueException("{$defaultField} should not be null");
+    }
     return \$this->{$defaultField};
 }
 EOT;

--- a/src/SectionField/Generator/EntityGenerator.php
+++ b/src/SectionField/Generator/EntityGenerator.php
@@ -226,6 +226,9 @@ class EntityGenerator extends Generator implements GeneratorInterface
             return <<<EOT
 public function getSlug(): Tardigrades\SectionField\ValueObject\Slug
 {
+    if (\$this->{$slugField} === null) {
+        throw new \UnexpectedValueException('\$this->{$slugField} is null, cannot build slug');
+    }
     return Tardigrades\SectionField\ValueObject\Slug::fromString(\$this->{$slugField});
 }
 EOT;
@@ -240,7 +243,7 @@ EOT;
 public function getDefault(): string
 {
     if (\$this->{$defaultField} === null) {
-        throw new \UnexpectedValueException("{$defaultField} should not be null");
+        throw new \UnexpectedValueException('\$this->{$defaultField} is null, cannot get default value');
     }
     return \$this->{$defaultField};
 }

--- a/src/SectionField/Generator/GeneratorTemplate/entity.php.template
+++ b/src/SectionField/Generator/GeneratorTemplate/entity.php.template
@@ -13,7 +13,7 @@ class {{ section }} implements CommonSectionInterface
 {
     {{ properties }}
 
-    /** @var int */
+    /** @var ?int */
     private $id;
 
     public function __construct()

--- a/test/unit/FieldType/Generator/EntityPropertiesGeneratorTest.php
+++ b/test/unit/FieldType/Generator/EntityPropertiesGeneratorTest.php
@@ -18,10 +18,10 @@ final class EntityPropertiesGeneratorTest extends TestCase
      * @test
      * @covers ::generate
      */
-    public function it_should_generate_when_property_is_not_nullable()
+    public function it_should_generate()
     {
         $body = <<<'EOT'
-/** @var {{ nullable }}\DateTime */
+/** @var ?\DateTime */
 protected ${{ propertyName }};
 
 EOT;
@@ -43,101 +43,6 @@ EOT;
                     'entity' => [
                         'validator' => [
                             'NotBlank' => null
-                        ]
-                    ]
-                ]
-            ]
-        ];
-
-        $templateString = <<<'EOT'
-/** @var \DateTime */
-protected $bar;
-
-EOT;
-
-        $field = new Field();
-        $field->setConfig($config);
-
-        $result = EntityPropertiesGenerator::generate($field, $templateDir);
-        $expected = Template::create($templateString);
-
-        $this->assertEquals($expected, $result);
-    }
-
-    /**
-     * @test
-     * @covers ::generate
-     */
-    public function it_should_generate_when_property_is_nullable()
-    {
-        $body = <<<'EOT'
-/** @var {{ nullable }}\DateTime */
-protected ${{ propertyName }};
-
-EOT;
-
-        $structure = [
-            'GeneratorTemplate' => [
-                'entity.properties.php.template' => $body
-            ]
-        ];
-        vfsStream::setup('root', null, $structure);
-
-        $templateDir = TemplateDir::fromString('vfs://root');
-
-        $config = [
-            'field' => [
-                'name' => 'foo',
-                'handle' => 'bar'
-            ]
-        ];
-
-        $templateString = <<<'EOT'
-/** @var ?\DateTime */
-protected $bar;
-
-EOT;
-
-        $field = new Field();
-        $field->setConfig($config);
-
-        $result = EntityPropertiesGenerator::generate($field, $templateDir);
-        $expected = Template::create($templateString);
-
-        $this->assertEquals($expected, $result);
-    }
-
-    /**
-     * @test
-     * @covers ::generate
-     */
-    public function it_should_generate_when_property_is_nullable_and_generator_has_other_config()
-    {
-        $body = <<<'EOT'
-/** @var {{ nullable }}\DateTime */
-protected ${{ propertyName }};
-
-EOT;
-
-        $structure = [
-            'GeneratorTemplate' => [
-                'entity.properties.php.template' => $body
-            ]
-        ];
-        vfsStream::setup('root', null, $structure);
-
-        $templateDir = TemplateDir::fromString('vfs://root');
-
-        $config = [
-            'field' => [
-                'name' => 'foo',
-                'handle' => 'bar',
-                'generator' => [
-                    'entity' => [
-                        'validator' => [
-                            'Length' => [
-                                'max' => 255
-                            ]
                         ]
                     ]
                 ]

--- a/test/unit/FieldType/Relationship/Generator/EntityMethodsGeneratorTest.php
+++ b/test/unit/FieldType/Relationship/Generator/EntityMethodsGeneratorTest.php
@@ -36,7 +36,7 @@ final class EntityMethodsGeneratorTest extends TestCase
                 ]
             ],
             <<<'EOT'
-public function getMes(): ?Collection
+public function getMes(): Collection
 {
     return $this->mes;
 }
@@ -86,7 +86,7 @@ EOT
                 ]
             ],
             <<<'EOT'
-public function getSomethingElses(): ?Collection
+public function getSomethingElses(): Collection
 {
     return $this->somethingElses;
 }

--- a/test/unit/FieldType/Relationship/Generator/EntityMethodsGeneratorTest.php
+++ b/test/unit/FieldType/Relationship/Generator/EntityMethodsGeneratorTest.php
@@ -162,6 +162,7 @@ public function removeMe(): {{ section }}
     if ($this->me === null) {
         return $this;
     }
+    /** @var Me */
     $me = $this->me;
     $this->me = null;
     $me->removeParticularMyClass($this);

--- a/test/unit/FieldType/Relationship/Generator/EntityMethodsGeneratorTest.php
+++ b/test/unit/FieldType/Relationship/Generator/EntityMethodsGeneratorTest.php
@@ -131,7 +131,8 @@ EOT
                     'kind' => 'many-to-one',
                     'relationship-type' => 'bidirectional',
                     'entityEvents' => ['1', '2'],
-                    'to' => 'me'
+                    'to' => 'me',
+                    'from-handle' => 'ParticularMyClass'
                 ]
             ],
             <<<'EOT'
@@ -151,7 +152,7 @@ public function setMe(Me $me): {{ section }}
         return $this;
     }
     $this->me = $me;
-    $me->addMyClass($this);
+    $me->addParticularMyClass($this);
 
     return $this;
 }
@@ -163,7 +164,7 @@ public function removeMe(): {{ section }}
     }
     $me = $this->me;
     $this->me = null;
-    $me->removeMyClass($this);
+    $me->removeParticularMyClass($this);
 
     return $this;
 }

--- a/test/unit/FieldType/Relationship/Generator/EntityMethodsGeneratorTest.php
+++ b/test/unit/FieldType/Relationship/Generator/EntityMethodsGeneratorTest.php
@@ -30,6 +30,7 @@ final class EntityMethodsGeneratorTest extends TestCase
                     'name' => 'iets',
                     'handle' => 'niets',
                     'kind' => 'one-to-many',
+                    'relationship-type' => 'bidirectional',
                     'entityEvents' => ['1', '2'],
                     'to' => 'me'
                 ]
@@ -78,6 +79,7 @@ EOT
                     'name' => 'iets',
                     'handle' => 'niets',
                     'kind' => 'many-to-many',
+                    'relationship-type' => 'bidirectional',
                     'entityEvents' => ['1', '2'],
                     'to' => 'me',
                     'as' => 'somethingElse'
@@ -127,6 +129,7 @@ EOT
                     'name' => 'iets',
                     'handle' => 'niets',
                     'kind' => 'many-to-one',
+                    'relationship-type' => 'bidirectional',
                     'entityEvents' => ['1', '2'],
                     'to' => 'me'
                 ]
@@ -174,6 +177,7 @@ EOT
                     'name' => 'iets',
                     'handle' => 'niets',
                     'kind' => 'one-to-one',
+                    'relationship-type' => 'unidirectional',
                     'entityEvents' => ['1', '2'],
                     'to' => 'me'
                 ]
@@ -195,7 +199,6 @@ public function setMe(Me $me): {{ section }}
         return $this;
     }
     $this->me = $me;
-    $me->setMyClass($this);
 
     return $this;
 }
@@ -205,9 +208,7 @@ public function removeMe(): {{ section }}
     if ($this->me === null) {
         return $this;
     }
-    $me = $this->me;
     $this->me = null;
-    $me->removeMyClass();
 
     return $this;
 }

--- a/test/unit/FieldType/Relationship/Generator/EntityMethodsGeneratorTest.php
+++ b/test/unit/FieldType/Relationship/Generator/EntityMethodsGeneratorTest.php
@@ -162,7 +162,7 @@ public function removeMe(): {{ section }}
     if ($this->me === null) {
         return $this;
     }
-    /** @var Me */
+    /** @var Me $me */
     $me = $this->me;
     $this->me = null;
     $me->removeParticularMyClass($this);

--- a/test/unit/FieldType/Relationship/Generator/EntityMethodsGeneratorTest.php
+++ b/test/unit/FieldType/Relationship/Generator/EntityMethodsGeneratorTest.php
@@ -158,6 +158,7 @@ public function removeMe(): {{ section }}
     if ($this->me === null) {
         return $this;
     }
+    $me = $this->me;
     $this->me = null;
     $me->removeMyClass($this);
 
@@ -204,6 +205,7 @@ public function removeMe(): {{ section }}
     if ($this->me === null) {
         return $this;
     }
+    $me = $this->me;
     $this->me = null;
     $me->removeMyClass();
 

--- a/test/unit/FieldType/Slug/Generator/EntityPrePersistGeneratorTest.php
+++ b/test/unit/FieldType/Slug/Generator/EntityPrePersistGeneratorTest.php
@@ -50,15 +50,17 @@ class EntityPrePersistGeneratorTest extends TestCase
         $this->assertFalse((string)$generatedTemplate === '');
 
         $expected = <<<'EOT'
-// phpcs:ignore Generic.Files.LineLength
-if ($this->getSnail() === null) {
+$snail = $this->getSnail();
+if ($snail === null) {
     throw new \UnexpectedValueException('snail is null, cannot build slug');
 }
-if ($this->getSexy() === null) {
+$sexy = $this->getSexy();
+if ($sexy === null) {
     throw new \UnexpectedValueException('sexy is null, cannot build slug');
 }
 
-$this->niets = Tardigrades\Helper\StringConverter::toSlug($this->getSnail() . '-' . $this->getSexy()->format('Y-m-d'));
+// phpcs:ignore Generic.Files.LineLength
+$this->niets = Tardigrades\Helper\StringConverter::toSlug($snail . '-' . $sexy->format('Y-m-d'));
 
 EOT;
 

--- a/test/unit/FieldType/Slug/Generator/EntityPrePersistGeneratorTest.php
+++ b/test/unit/FieldType/Slug/Generator/EntityPrePersistGeneratorTest.php
@@ -23,7 +23,7 @@ class EntityPrePersistGeneratorTest extends TestCase
     public function it_should_generate()
     {
         $mockedFieldInterface = Mockery::mock(new Field())->makePartial();
-        $templateDir = TemplateDir::fromString('src/FieldType/Slug');
+        $templateDir = TemplateDir::fromString(__DIR__ . '/../../../../../src/FieldType/Slug');
 
         $mockedFieldInterface->shouldReceive('getConfig')
             ->andReturn(
@@ -49,11 +49,19 @@ class EntityPrePersistGeneratorTest extends TestCase
         $this->assertInstanceOf(Template::class, $generatedTemplate);
         $this->assertFalse((string)$generatedTemplate === '');
 
-        // @codingStandardsIgnoreStart
-        $this->assertContains(
-            '$this->niets = Tardigrades\Helper\StringConverter::toSlug($this->getSnail() . \'-\' . $this->getSexy()->format(\'Y-m-d\'));',
-            (string) $generatedTemplate
-        );
-        // @codingStandardsIgnoreEnd
+        $expected = <<<'EOT'
+// phpcs:ignore Generic.Files.LineLength
+if ($this->getSnail() === null) {
+    throw new \UnexpectedValueException('snail is null, cannot build slug');
+}
+if ($this->getSexy() === null) {
+    throw new \UnexpectedValueException('sexy is null, cannot build slug');
+}
+
+$this->niets = Tardigrades\Helper\StringConverter::toSlug($this->getSnail() . '-' . $this->getSexy()->format('Y-m-d'));
+
+EOT;
+
+        $this->assertSame($expected, (string)$generatedTemplate);
     }
 }


### PR DESCRIPTION
This changes the generated code so it passes through Psalm without warnings or errors. It handles bidirectional relationships more cleanly to keep the two sides in sync and call the right methods, checks for null where necessary, and uses nullable types if and only if the value can be null.

`from-handle` can now be used in relationships to specify the alias that's used on the other side. See 9702c49c4fbf3aec463378ac2e46ac5904d324df.