### PR TITLE
Field info method

### DIFF
--- a/src/SectionField/Generator/EntityGenerator.php
+++ b/src/SectionField/Generator/EntityGenerator.php
@@ -381,14 +381,21 @@ EOT;
         // Better indentation
         $content = preg_replace('/=> \\n */', '=> ', $content);
         $content = str_replace('  ', '    ', $content);
-        $content = str_replace("\n", "\n    ", $content);
+        $content = str_replace("\n", "\n        ", $content);
 
         // PSR2-conforming null constant
         $content = str_replace('=> NULL', '=> null', $content);
 
         return str_replace(
             '{{ metadata }}',
-            "    const FIELDS = $content;\n",
+            <<< EOF
+
+    public static function fieldInfo()
+    {
+        return $content;
+    }
+EOF
+            ,
             $template
         );
     }

--- a/src/SectionField/Generator/EntityGenerator.php
+++ b/src/SectionField/Generator/EntityGenerator.php
@@ -390,7 +390,7 @@ EOT;
             '{{ metadata }}',
             <<< EOF
 
-    public static function fieldInfo()
+    public static function fieldInfo(): array
     {
         return $content;
     }

--- a/src/SectionField/Generator/EntityGenerator.php
+++ b/src/SectionField/Generator/EntityGenerator.php
@@ -116,7 +116,8 @@ class EntityGenerator extends Generator implements GeneratorInterface
                 $relationship = [
                     'class' => $targetClass,
                     'plural' => $plural,
-                    'kind' => $kind
+                    'kind' => $kind,
+                    'owner' => $fieldConfigArray['field']['owner']
                 ];
             } else {
                 $propertyName = (string)$fieldConfig->getPropertyName();

--- a/src/SectionField/Generator/EntityGenerator.php
+++ b/src/SectionField/Generator/EntityGenerator.php
@@ -382,21 +382,14 @@ EOT;
         // Better indentation
         $content = preg_replace('/=> \\n */', '=> ', $content);
         $content = str_replace('  ', '    ', $content);
-        $content = str_replace("\n", "\n        ", $content);
+        $content = str_replace("\n", "\n    ", $content);
 
         // PSR2-conforming null constant
         $content = str_replace('=> NULL', '=> null', $content);
 
         return str_replace(
             '{{ metadata }}',
-            <<< EOF
-
-    public static function fieldInfo(): array
-    {
-        return $content;
-    }
-EOF
-            ,
+            "    const FIELDS = $content;\n",
             $template
         );
     }

--- a/src/SectionField/Generator/GeneratorTemplate/entity.php.template
+++ b/src/SectionField/Generator/GeneratorTemplate/entity.php.template
@@ -11,6 +11,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class {{ section }} implements CommonSectionInterface
 {
+    {{ metadata }}
+
     {{ properties }}
 
     /** @var ?int */
@@ -20,8 +22,6 @@ class {{ section }} implements CommonSectionInterface
     {
         {{ constructor }}
     }
-
-    {{ metadata }}
 
     public function getId(): ?int
     {
@@ -46,5 +46,10 @@ class {{ section }} implements CommonSectionInterface
     public function onPreUpdate(): void
     {
         {{ preUpdate }}
+    }
+
+    public static function fieldInfo(): array
+    {
+        return static::FIELDS;
     }
 }

--- a/src/SectionField/Generator/GeneratorTemplate/entity.php.template
+++ b/src/SectionField/Generator/GeneratorTemplate/entity.php.template
@@ -11,8 +11,6 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class {{ section }} implements CommonSectionInterface
 {
-    {{ metadata }}
-
     {{ properties }}
 
     /** @var ?int */
@@ -22,6 +20,8 @@ class {{ section }} implements CommonSectionInterface
     {
         {{ constructor }}
     }
+
+    {{ metadata }}
 
     public function getId(): ?int
     {


### PR DESCRIPTION
Replace the `::FIELDS` constant by a `::fieldInfo()` static method, for easier mocking. See dionsnoeijen/sexy-field#92.

Fixes in other code will be needed, but a straightforward find/replace should be enough in most cases.