### PR TITLE
Add a way for sections to add custom extra methods in a trait

### DIFF
--- a/src/SectionField/Generator/EntityGenerator.php
+++ b/src/SectionField/Generator/EntityGenerator.php
@@ -476,6 +476,13 @@ EOT;
         return $template;
     }
 
+    private function insertExtraMethods(string $template): string
+    {
+        $config = $this->sectionConfig->toArray();
+        $methods = $config['section']['extraMethods'] ?? '';
+        return str_replace('{{ extraMethods }}', $methods, $template);
+    }
+
     private function generateEntity(): Template
     {
         $template = TemplateLoader::load(__DIR__ . '/GeneratorTemplate/entity.php.template');
@@ -486,6 +493,7 @@ EOT;
         $template = $this->insertSection($template);
         $template = $this->insertNamespace($template);
         $template = $this->insertValidationMetadata($template);
+        $template = $this->insertExtraMethods($template);
         $template = PhpFormatter::format($template);
         $template = $this->insertFieldMetadata($template);
 

--- a/src/SectionField/Generator/EntityGenerator.php
+++ b/src/SectionField/Generator/EntityGenerator.php
@@ -403,7 +403,7 @@ EOT;
 
         return str_replace(
             '{{ metadata }}',
-            "    const FIELDS = $content;\n",
+            "\n    const FIELDS = $content;\n",
             $template
         );
     }
@@ -476,13 +476,6 @@ EOT;
         return $template;
     }
 
-    private function insertExtraMethods(string $template): string
-    {
-        $config = $this->sectionConfig->toArray();
-        $methods = $config['section']['extraMethods'] ?? '';
-        return str_replace('{{ extraMethods }}', $methods, $template);
-    }
-
     private function generateEntity(): Template
     {
         $template = TemplateLoader::load(__DIR__ . '/GeneratorTemplate/entity.php.template');
@@ -493,7 +486,6 @@ EOT;
         $template = $this->insertSection($template);
         $template = $this->insertNamespace($template);
         $template = $this->insertValidationMetadata($template);
-        $template = $this->insertExtraMethods($template);
         $template = PhpFormatter::format($template);
         $template = $this->insertFieldMetadata($template);
 

--- a/src/SectionField/Generator/EntityTraitGenerator.php
+++ b/src/SectionField/Generator/EntityTraitGenerator.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Tardigrades\SectionField\Generator;
+
+use Tardigrades\Entity\SectionInterface;
+use Tardigrades\SectionField\Generator\Loader\TemplateLoader;
+use Tardigrades\SectionField\Generator\Writer\Writable;
+
+class EntityTraitGenerator extends Generator implements GeneratorInterface
+{
+    public function generateBySection(SectionInterface $section): Writable
+    {
+        $sectionConfig = $section->getConfig();
+        $namespace = $sectionConfig->getNamespace() . '\\Entity\\Extra';
+        $class = $sectionConfig->getClassName() . 'Trait';
+
+        $template = TemplateLoader::load(__DIR__ . '/GeneratorTemplate/entitytrait.php.template');
+        $template = str_replace(
+            ['{{ namespace }}', '{{ section }}'],
+            [$namespace, $class],
+            $template
+        );
+
+        return Writable::create(
+            $template,
+            $namespace . '\\',
+            "$class.php",
+            false
+        );
+    }
+}

--- a/src/SectionField/Generator/GeneratorTemplate/entity.php.template
+++ b/src/SectionField/Generator/GeneratorTemplate/entity.php.template
@@ -52,4 +52,6 @@ class {{ section }} implements CommonSectionInterface
     {
         return static::FIELDS;
     }
+
+    {{ extraMethods }}
 }

--- a/src/SectionField/Generator/GeneratorTemplate/entity.php.template
+++ b/src/SectionField/Generator/GeneratorTemplate/entity.php.template
@@ -11,6 +11,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class {{ section }} implements CommonSectionInterface
 {
+    use Extra\{{ section }}Trait;
+
     {{ metadata }}
 
     {{ properties }}
@@ -52,6 +54,4 @@ class {{ section }} implements CommonSectionInterface
     {
         return static::FIELDS;
     }
-
-    {{ extraMethods }}
 }

--- a/src/SectionField/Generator/GeneratorTemplate/entitytrait.php.template
+++ b/src/SectionField/Generator/GeneratorTemplate/entitytrait.php.template
@@ -1,0 +1,8 @@
+<?php
+declare (strict_types=1);
+
+namespace {{ namespace }};
+
+trait {{ section }}
+{
+}

--- a/src/config/service/services.yml
+++ b/src/config/service/services.yml
@@ -7,4 +7,14 @@ services:
       $sectionManager: '@Tardigrades\SectionField\Service\DoctrineSectionManager'
       $container: '@service_container'
 
+  Tardigrades\SectionField\Generator\EntityTraitGenerator:
+    autowire: false
+    arguments:
+      $fieldManager: '@Tardigrades\SectionField\Service\DoctrineFieldManager'
+      $fieldTypeManager: '@Tardigrades\SectionField\Service\DoctrineFieldTypeManager'
+      $sectionManager: '@Tardigrades\SectionField\Service\DoctrineSectionManager'
+      $container: '@service_container'
+
   section_field.generator.entity_generator: '@Tardigrades\SectionField\Generator\EntityGenerator'
+
+  section_field.generator.entity_trait_generator: '@Tardigrades\SectionField\Generator\EntityTraitGenerator'


### PR DESCRIPTION
This makes it possible to define custom extra methods ~~on a generated section class.~~

~~For example:~~
```yaml
section:
  name: My section
  [...]
  generator:
    entity:
  extraMethods: |-
    public function getFooBar(): string
    {
        return $this->getFoo()->getBar();
    }
```
~~(`|-` is just YAML syntax for multi-line strings)~~

For each entity `Foo`, a `Extra\FooTrait` is generated in which custom code can safely be written.