### PR TITLE
Fix issue where referenced variable causes issues

### DIFF
--- a/src/SectionField/Generator/EntityGenerator.php
+++ b/src/SectionField/Generator/EntityGenerator.php
@@ -251,6 +251,8 @@ class EntityGenerator extends Generator implements GeneratorInterface
             }
         }
 
+        unset($info);
+
         usort($this->preUpdateInfo, function($a, $b) {
             return
                 $a['config'][self::GENERATE_FOR]['preUpdateOrder'] <=>

--- a/src/SectionField/Generator/EntityGenerator.php
+++ b/src/SectionField/Generator/EntityGenerator.php
@@ -224,6 +224,8 @@ class EntityGenerator extends Generator implements GeneratorInterface
             }
         }
 
+        unset($info);
+
         usort($this->prePersistInfo, function($a, $b) {
             return
                 $a['config'][self::GENERATE_FOR]['prePersistOrder'] <=>


### PR DESCRIPTION
https://stackoverflow.com/questions/3307409/php-pass-by-reference-in-foreach
https://www.php.net/manual/en/control-structures.foreach.php

In some cases the prePersist section of an entity wasn't generated correctly.
This was caused by re-using a referenced variable in a second foreach.